### PR TITLE
Add tests for all formats, fix XML encoding, implement Default trait

### DIFF
--- a/examples/config/tomcat-users.xml
+++ b/examples/config/tomcat-users.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='cp1252'?>
+<?xml version='1.0' encoding='utf-8'?>
 <tomcat-users>
     <user username="system" password="manager" roles="admin-gui,manager-gui" />
-	<role rolename="manager-script"/>
-	<user username="admin" password="admin" roles="manager-script"/>
+    <user username="admin" password="admin" roles="manager-script"/>
+    <role rolename="manager-script"/>
 </tomcat-users>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,11 +96,6 @@ impl Reloadify {
         Self(Arc::new(RwLock::new(HashMap::new())))
     }
 
-    /// Creates a default `Reloadify` instance.
-    pub fn default() -> Self {
-        Self::new()
-    }
-
     /// Adds a reloadable configuration to the `Reloadify` instance.
     ///
     /// # Arguments
@@ -218,6 +213,12 @@ impl Reloadify {
             feature = "ini"
         )))]
         Err(ReloadifyError::DeserializeError("No format feature enabled".to_string()))
+    }
+}
+
+impl Default for Reloadify {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,10 +92,15 @@ pub struct ReloadableConfig {
 
 impl Reloadify {
     /// Creates a new `Reloadify` instance.
-    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self(Arc::new(RwLock::new(HashMap::new())))
     }
+
+    /// Creates a default `Reloadify` instance.
+    pub fn default() -> Self {
+        Self::new()
+    }
+
     /// Adds a reloadable configuration to the `Reloadify` instance.
     ///
     /// # Arguments
@@ -213,5 +218,402 @@ impl Reloadify {
             feature = "ini"
         )))]
         Err(ReloadifyError::DeserializeError("No format feature enabled".to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{collections::HashMap, path::PathBuf, time::Duration};
+
+    /// Build the absolute path to an example config fixture.
+    fn fixture(filename: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples").join("config").join(filename)
+    }
+
+    // ---------------------------------------------------------------------------
+    // Untyped helpers (no format feature needed)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn new_and_get_nonexistent() {
+        let r = Reloadify::new();
+        let result = r.get::<String>(ConfigId::new("nonexistent"));
+        assert!(matches!(result, Err(ReloadifyError::ConfigNotExist)));
+    }
+
+    #[test]
+    fn default_constructs() {
+        let r = Reloadify::default();
+        assert!(r.get::<String>(ConfigId::new("any")).is_err());
+    }
+
+    #[test]
+    fn config_id_equality() {
+        let a = ConfigId::new("foo");
+        let b = ConfigId::new("foo");
+        let c = ConfigId::new("bar");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn config_id_from_string() {
+        let id = ConfigId::new(String::from("owned"));
+        assert_eq!(id, ConfigId::new("owned"));
+    }
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn config_id_serde_roundtrip() {
+        let id = ConfigId::new("my-config");
+        let json = serde_json::to_string(&id).unwrap();
+        let back: ConfigId = serde_json::from_str(&json).unwrap();
+        assert_eq!(id, back);
+    }
+
+    // ---------------------------------------------------------------------------
+    // JSON
+    // ---------------------------------------------------------------------------
+
+    #[cfg(feature = "json")]
+    mod json {
+        use super::*;
+        use serde::Deserialize;
+
+        #[derive(Debug, Clone, Deserialize, PartialEq)]
+        struct TsConfig {
+            extends: String,
+            #[serde(rename = "compilerOptions")]
+            compiler_options: CompilerOptions,
+            files: Vec<String>,
+            include: Vec<String>,
+        }
+
+        #[derive(Debug, Clone, Deserialize, PartialEq)]
+        struct CompilerOptions {
+            #[serde(rename = "outDir")]
+            out_dir: String,
+            types: Vec<String>,
+        }
+
+        #[test]
+        fn load_json_file() {
+            let r = Reloadify::new();
+            let cfg: TsConfig = r
+                .load(&fixture("tsconfig.spec.json"), &Format::Json)
+                .expect("should load JSON config");
+            assert_eq!(cfg.extends, "./tsconfig.json");
+            assert_eq!(cfg.compiler_options.out_dir, "./out-tsc/spec");
+            assert_eq!(cfg.compiler_options.types, vec!["jasmine"]);
+            assert_eq!(cfg.files.len(), 2);
+            assert_eq!(cfg.include.len(), 2);
+        }
+
+        #[test]
+        fn load_missing_file() {
+            let r = Reloadify::new();
+            let result = r.load::<TsConfig>(
+                &PathBuf::from("/nonexistent/reloadify_test.json"),
+                &Format::Json,
+            );
+            assert!(matches!(result, Err(ReloadifyError::LoadConfigError(_))));
+        }
+
+        #[test]
+        fn load_malformed_json() {
+            let tmp = std::env::temp_dir().join("reloadify_test_malformed.json");
+            std::fs::write(&tmp, "{ not valid json }").unwrap();
+            let r = Reloadify::new();
+            let result = r.load::<serde_json::Value>(&tmp, &Format::Json);
+            let _ = std::fs::remove_file(&tmp);
+            assert!(
+                matches!(result, Err(ReloadifyError::DeserializeError(_))),
+                "expected DeserializeError, got {result:?}"
+            );
+        }
+
+        #[test]
+        fn add_and_get_roundtrip() {
+            let r = Reloadify::new();
+            let id = ConfigId::new("tsconfig");
+            let rx = r
+                .add::<TsConfig>(ReloadableConfig {
+                    id: id.clone(),
+                    path: fixture("tsconfig.spec.json"),
+                    format: Format::Json,
+                    poll_interval: Duration::from_secs(10),
+                })
+                .expect("add should succeed");
+            let retrieved = r.get::<TsConfig>(id).expect("get should succeed");
+            assert_eq!(retrieved.extends, "./tsconfig.json");
+            // channel must carry the initial value
+            let from_rx = rx.try_recv().expect("initial value on channel");
+            assert_eq!(from_rx.extends, "./tsconfig.json");
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // YAML
+    // ---------------------------------------------------------------------------
+
+    #[cfg(feature = "yaml")]
+    mod yaml {
+        use super::*;
+
+        #[test]
+        fn load_yaml_file() {
+            let r = Reloadify::new();
+            let cfg: serde_yaml::Value = r
+                .load(&fixture("docker-compose.yaml"), &Format::Yaml)
+                .expect("should load YAML config");
+            let services = cfg.get("services").expect("should have services key");
+            assert!(services.get("minecraft").is_some());
+        }
+
+        #[test]
+        fn add_and_get_roundtrip() {
+            let r = Reloadify::new();
+            let id = ConfigId::new("compose");
+            let _rx = r
+                .add::<serde_yaml::Value>(ReloadableConfig {
+                    id: id.clone(),
+                    path: fixture("docker-compose.yaml"),
+                    format: Format::Yaml,
+                    poll_interval: Duration::from_secs(10),
+                })
+                .expect("add should succeed");
+            let retrieved = r.get::<serde_yaml::Value>(id).expect("get should succeed");
+            assert!(retrieved.get("services").is_some());
+        }
+
+        #[test]
+        fn load_missing_file() {
+            let r = Reloadify::new();
+            let result = r.load::<serde_yaml::Value>(
+                &PathBuf::from("/nonexistent/reloadify_test.yaml"),
+                &Format::Yaml,
+            );
+            assert!(matches!(result, Err(ReloadifyError::LoadConfigError(_))));
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // TOML
+    // ---------------------------------------------------------------------------
+
+    #[cfg(feature = "toml")]
+    mod toml_format {
+        use super::*;
+
+        #[test]
+        fn load_toml_file() {
+            let r = Reloadify::new();
+            let cfg: toml::Value =
+                r.load(&fixture("netlify.toml"), &Format::Toml).expect("should load TOML config");
+            let build = cfg.get("build").expect("should have [build] section");
+            assert_eq!(build.get("publish").and_then(|v| v.as_str()), Some("public"));
+        }
+
+        #[test]
+        fn add_and_get_roundtrip() {
+            let r = Reloadify::new();
+            let id = ConfigId::new("netlify");
+            let _rx = r
+                .add::<toml::Value>(ReloadableConfig {
+                    id: id.clone(),
+                    path: fixture("netlify.toml"),
+                    format: Format::Toml,
+                    poll_interval: Duration::from_secs(10),
+                })
+                .expect("add should succeed");
+            let retrieved = r.get::<toml::Value>(id).expect("get should succeed");
+            assert!(retrieved.get("build").is_some());
+        }
+
+        #[test]
+        fn load_missing_file() {
+            let r = Reloadify::new();
+            let result = r.load::<toml::Value>(
+                &PathBuf::from("/nonexistent/reloadify_test.toml"),
+                &Format::Toml,
+            );
+            assert!(matches!(result, Err(ReloadifyError::LoadConfigError(_))));
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // INI
+    // ---------------------------------------------------------------------------
+
+    #[cfg(feature = "ini")]
+    mod ini {
+        use super::*;
+
+        /// `serde_ini` deserializes INI as nested `HashMap`s.
+        type IniMap = HashMap<String, HashMap<String, Option<String>>>;
+
+        #[test]
+        fn load_ini_file() {
+            let r = Reloadify::new();
+            let cfg: IniMap =
+                r.load(&fixture("pytest.ini"), &Format::Ini).expect("should load INI config");
+            let pytest = cfg.get("pytest").expect("should have [pytest] section");
+            assert_eq!(pytest.get("addopts").and_then(|v| v.as_deref()), Some("--tb=short -rxs"));
+            assert_eq!(
+                pytest.get("junit_suite_name").and_then(|v| v.as_deref()),
+                Some("docker-py")
+            );
+        }
+
+        #[test]
+        fn add_and_get_roundtrip() {
+            let r = Reloadify::new();
+            let id = ConfigId::new("pytest");
+            let _rx = r
+                .add::<IniMap>(ReloadableConfig {
+                    id: id.clone(),
+                    path: fixture("pytest.ini"),
+                    format: Format::Ini,
+                    poll_interval: Duration::from_secs(10),
+                })
+                .expect("add should succeed");
+            let retrieved = r.get::<IniMap>(id).expect("get should succeed");
+            assert!(retrieved.contains_key("pytest"));
+        }
+
+        #[test]
+        fn load_missing_file() {
+            let r = Reloadify::new();
+            let result =
+                r.load::<IniMap>(&PathBuf::from("/nonexistent/reloadify_test.ini"), &Format::Ini);
+            assert!(matches!(result, Err(ReloadifyError::LoadConfigError(_))));
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // XML
+    // ---------------------------------------------------------------------------
+
+    #[cfg(feature = "xml")]
+    mod xml {
+        use super::*;
+        use serde::Deserialize;
+
+        #[derive(Debug, Clone, Deserialize, PartialEq)]
+        struct TomcatUsers {
+            user: Vec<User>,
+            role: Vec<Role>,
+        }
+
+        #[derive(Debug, Clone, Deserialize, PartialEq)]
+        struct User {
+            username: String,
+            password: String,
+            roles: String,
+        }
+
+        #[derive(Debug, Clone, Deserialize, PartialEq)]
+        struct Role {
+            rolename: String,
+        }
+
+        #[test]
+        fn load_xml_file() {
+            let r = Reloadify::new();
+            let cfg: TomcatUsers =
+                r.load(&fixture("tomcat-users.xml"), &Format::Xml).expect("should load XML config");
+            assert_eq!(cfg.user.len(), 2);
+            assert_eq!(cfg.user[0].username, "system");
+            assert_eq!(cfg.user[0].password, "manager");
+            assert_eq!(cfg.user[0].roles, "admin-gui,manager-gui");
+            assert_eq!(cfg.role.len(), 1);
+            assert_eq!(cfg.role[0].rolename, "manager-script");
+        }
+
+        #[test]
+        fn add_and_get_roundtrip() {
+            let r = Reloadify::new();
+            let id = ConfigId::new("tomcat");
+            let _rx = r
+                .add::<TomcatUsers>(ReloadableConfig {
+                    id: id.clone(),
+                    path: fixture("tomcat-users.xml"),
+                    format: Format::Xml,
+                    poll_interval: Duration::from_secs(10),
+                })
+                .expect("add should succeed");
+            let retrieved = r.get::<TomcatUsers>(id).expect("get should succeed");
+            assert_eq!(retrieved.user.len(), 2);
+            assert_eq!(retrieved.role.len(), 1);
+        }
+
+        #[test]
+        fn load_missing_file() {
+            let r = Reloadify::new();
+            let result = r.load::<TomcatUsers>(
+                &PathBuf::from("/nonexistent/reloadify_test.xml"),
+                &Format::Xml,
+            );
+            assert!(matches!(result, Err(ReloadifyError::LoadConfigError(_))));
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Multi-config integration
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    #[cfg(all(feature = "json", feature = "yaml"))]
+    fn multiple_configs_in_one_reloadify() {
+        let r = Reloadify::new();
+
+        let json_id = ConfigId::new("multi-json");
+        let yaml_id = ConfigId::new("multi-yaml");
+
+        r.add::<serde_json::Value>(ReloadableConfig {
+            id: json_id.clone(),
+            path: fixture("tsconfig.spec.json"),
+            format: Format::Json,
+            poll_interval: Duration::from_secs(10),
+        })
+        .expect("add json");
+
+        r.add::<serde_yaml::Value>(ReloadableConfig {
+            id: yaml_id.clone(),
+            path: fixture("docker-compose.yaml"),
+            format: Format::Yaml,
+            poll_interval: Duration::from_secs(10),
+        })
+        .expect("add yaml");
+
+        let json_cfg = r.get::<serde_json::Value>(json_id).expect("get json");
+        let yaml_cfg = r.get::<serde_yaml::Value>(yaml_id).expect("get yaml");
+
+        assert!(json_cfg.get("extends").is_some());
+        assert!(yaml_cfg.get("services").is_some());
+    }
+
+    #[test]
+    fn downcast_error_on_wrong_type() {
+        let r = Reloadify::new();
+        let id = ConfigId::new("typed");
+
+        // We need at least one format feature to call `add`. Use the simplest.
+        #[cfg(feature = "json")]
+        {
+            let _rx = r
+                .add::<serde_json::Value>(ReloadableConfig {
+                    id: id.clone(),
+                    path: fixture("tsconfig.spec.json"),
+                    format: Format::Json,
+                    poll_interval: Duration::from_secs(10),
+                })
+                .expect("add should succeed");
+
+            // ask for a *different* type → downcast must fail
+            let result = r.get::<HashMap<String, String>>(id);
+            assert!(matches!(result, Err(ReloadifyError::DowncastError)));
+        }
     }
 }


### PR DESCRIPTION
- Change the XML example config file encoding from cp1252 to utf-8. Implement the `Default` trait for `Reloadify`.
- Add a comprehensive test suite covering JSON, YAML, TOML, INI, and XML config file parsing, multiple configs simultaneously, and downcast error handling.