### PR TITLE
Add `remove` method and `From` impls for `ConfigId`

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,4 @@
-use reloadify::{ConfigId, Format, ReloadableConfig, Reloadify};
+use reloadify::{Format, ReloadableConfig, Reloadify};
 use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, str::FromStr, time::Duration};
 
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let reloadify = Reloadify::new();
 
     let rx = reloadify.add::<TsConfig>(ReloadableConfig {
-        id: ConfigId::new(TS_CONFIG_ID),
+        id: TS_CONFIG_ID.into(),
         path: PathBuf::from_str("examples/config/tsconfig.spec.json")?,
         format: Format::Json,
         poll_interval: Duration::from_secs(1),
@@ -38,7 +38,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    let ts_config = reloadify.get::<TsConfig>(ConfigId::new(TS_CONFIG_ID))?;
+    let ts_config = reloadify.get::<TsConfig>(TS_CONFIG_ID)?;
 
     // Do something with ts_config...
     println!("{:?}", ts_config);

--- a/examples/multi_format.rs
+++ b/examples/multi_format.rs
@@ -1,4 +1,4 @@
-use reloadify::{ConfigId, Format, ReloadableConfig, Reloadify};
+use reloadify::{Format, ReloadableConfig, Reloadify};
 use std::{path::PathBuf, str::FromStr, time::Duration};
 
 const COMPOSE_CONFIG_ID: &str = "docker-compose";
@@ -8,21 +8,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let reloadify = Reloadify::new();
 
     reloadify.add::<compose::ComposeConfig>(ReloadableConfig {
-        id: ConfigId::new(COMPOSE_CONFIG_ID),
+        id: COMPOSE_CONFIG_ID.into(),
         path: PathBuf::from_str("examples/config/docker-compose.yaml")?,
         format: Format::Yaml,
         poll_interval: Duration::from_secs(1),
     })?;
     reloadify.add::<pytest::PyTestConfig>(ReloadableConfig {
-        id: ConfigId::new(PYTEST_CONFIG_ID),
+        id: PYTEST_CONFIG_ID.into(),
         path: PathBuf::from_str("examples/config/pytest.ini")?,
         format: Format::Ini,
         poll_interval: Duration::from_millis(100),
     })?;
 
-    let compose_config =
-        reloadify.get::<compose::ComposeConfig>(ConfigId::new(COMPOSE_CONFIG_ID))?;
-    let pytest_config = reloadify.get::<pytest::PyTestConfig>(ConfigId::new(PYTEST_CONFIG_ID))?;
+    let compose_config = reloadify.get::<compose::ComposeConfig>(COMPOSE_CONFIG_ID)?;
+    let pytest_config = reloadify.get::<pytest::PyTestConfig>(PYTEST_CONFIG_ID)?;
 
     // Do something with compose_config and pytest_config...
     println!("compose_config={compose_config:?}\npytest_config={pytest_config:?}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,10 +44,23 @@ pub enum Format {
 /// Represents the identifier of a configuration.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
 pub struct ConfigId(String);
+
 impl ConfigId {
     /// Creates a new `ConfigId` with the given identifier.
     pub fn new<S: Into<String>>(id: S) -> Self {
         Self(id.into())
+    }
+}
+
+impl From<&str> for ConfigId {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+impl From<String> for ConfigId {
+    fn from(s: String) -> Self {
+        Self(s)
     }
 }
 
@@ -157,10 +170,11 @@ impl Reloadify {
     ///
     /// Returns a result containing the deserialized configuration if it exists, or an error if the
     /// configuration does not exist or an error occurred.
-    pub fn get<C>(&self, config_id: ConfigId) -> Result<C, ReloadifyError>
+    pub fn get<C>(&self, config_id: impl Into<ConfigId>) -> Result<C, ReloadifyError>
     where
         C: DeserializeOwned + Send + Sync + Clone + 'static,
     {
+        let config_id = config_id.into();
         match self.0.read() {
             Err(_) => Err(ReloadifyError::GetLockError),
             Ok(guard) => Ok(guard
@@ -171,6 +185,21 @@ impl Reloadify {
                 .cloned()
                 .ok_or(ReloadifyError::DowncastError)?),
         }
+    }
+
+    /// Removes a configuration, stopping its file watcher.
+    ///
+    /// The [`Receiver`] channel for this config will disconnect,
+    /// causing any listening loop to exit cleanly.
+    ///
+    /// # Arguments
+    ///
+    /// * `config_id` - The identifier of the configuration to remove.
+    pub fn remove(&self, config_id: impl Into<ConfigId>) -> Result<(), ReloadifyError> {
+        let config_id = config_id.into();
+        let mut guard = self.0.write().map_err(|_| ReloadifyError::GetLockError)?;
+        guard.remove(&config_id).ok_or(ReloadifyError::ConfigNotExist)?;
+        Ok(())
     }
 
     #[allow(unused_variables)]
@@ -237,14 +266,14 @@ mod tests {
     #[test]
     fn new_and_get_nonexistent() {
         let r = Reloadify::new();
-        let result = r.get::<String>(ConfigId::new("nonexistent"));
+        let result = r.get::<String>("nonexistent");
         assert!(matches!(result, Err(ReloadifyError::ConfigNotExist)));
     }
 
     #[test]
     fn default_constructs() {
         let r = Reloadify::default();
-        assert!(r.get::<String>(ConfigId::new("any")).is_err());
+        assert!(r.get::<String>("any").is_err());
     }
 
     #[test]
@@ -257,9 +286,68 @@ mod tests {
     }
 
     #[test]
+    fn config_id_from_str() {
+        let id: ConfigId = "mycfg".into();
+        assert_eq!(id, ConfigId::new("mycfg"));
+    }
+
+    #[test]
     fn config_id_from_string() {
-        let id = ConfigId::new(String::from("owned"));
+        let id = ConfigId::from(String::from("owned"));
         assert_eq!(id, ConfigId::new("owned"));
+    }
+
+    #[test]
+    fn get_with_str_literal() {
+        let r = Reloadify::new();
+        // &str passed directly — no ConfigId::new needed
+        let result = r.get::<String>("literal-key");
+        assert!(matches!(result, Err(ReloadifyError::ConfigNotExist)));
+    }
+
+    #[test]
+    fn remove_nonexistent() {
+        let r = Reloadify::new();
+        let result = r.remove("nonexistent");
+        assert!(matches!(result, Err(ReloadifyError::ConfigNotExist)));
+    }
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn remove_existing() {
+        let r = Reloadify::new();
+        let id = ConfigId::new("to-remove");
+        let _rx = r
+            .add::<serde_json::Value>(ReloadableConfig {
+                id: id.clone(),
+                path: fixture("tsconfig.spec.json"),
+                format: Format::Json,
+                poll_interval: Duration::from_secs(10),
+            })
+            .expect("add");
+        assert!(r.get::<serde_json::Value>(id.clone()).is_ok());
+        r.remove(id.clone()).expect("remove");
+        assert!(matches!(r.get::<serde_json::Value>(id), Err(ReloadifyError::ConfigNotExist)));
+    }
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn remove_disconnects_receiver() {
+        let r = Reloadify::new();
+        let id = ConfigId::new("dc-test");
+        let rx = r
+            .add::<serde_json::Value>(ReloadableConfig {
+                id: id.clone(),
+                path: fixture("tsconfig.spec.json"),
+                format: Format::Json,
+                poll_interval: Duration::from_secs(10),
+            })
+            .expect("add");
+        r.remove(id).expect("remove");
+        // After remove, the channel should be disconnected.
+        // Drain initial value first, then next recv should error.
+        let _ = rx.try_recv(); // initial value
+        assert!(rx.try_recv().is_err());
     }
 
     #[test]


### PR DESCRIPTION
- Implement `From<&str>` and `From<String>` for `ConfigId` to allow passing string literals to `get` and `add` without wrapping. - Add `remove` method to `Reloadify` to deregister a configuration and stop its file watcher. Update examples and tests.

Fixes #11